### PR TITLE
Fix newer SDCC compatibility (properly) and board detection

### DIFF
--- a/Libraries/STM8S_StdPeriph_Driver/Makefile
+++ b/Libraries/STM8S_StdPeriph_Driver/Makefile
@@ -22,7 +22,7 @@ endif
 CC_ROOT =
 CC      = sdcc
 CFLAGS  = -mstm8 -lstm8 --opt-code-size
-AR      = sdar
+AR      = sdcclib
 
 # set output folder and target name
 OUTPUT_DIR = ./$(DEVICE)
@@ -81,7 +81,7 @@ $(OUTPUT_DIR)/%.rel: %.c
 	$(CC) $(CFLAGS) $(INCLUDE) -D$(DEVICE) -c $? -o $@
 
 $(TARGET): $(PRJ_OBJECTS) $(SPL_OBJECTS) $(EVAL_OBJECTS) $(EVAL_COMM_OBJECTS) $(EVAL_STM8S_128K_OBJECTS)
-	$(AR) -rc $(TARGET) $^
+	$(AR) -a $(TARGET) $^
 
 clean: 
 	rm -fr $(OUTPUT_DIR)

--- a/Libraries/STM8S_StdPeriph_Driver/Makefile
+++ b/Libraries/STM8S_StdPeriph_Driver/Makefile
@@ -22,7 +22,7 @@ endif
 CC_ROOT =
 CC      = sdcc
 CFLAGS  = -mstm8 -lstm8 --opt-code-size
-AR      = sdcclib
+AR      = sdar
 
 # set output folder and target name
 OUTPUT_DIR = ./$(DEVICE)
@@ -81,7 +81,7 @@ $(OUTPUT_DIR)/%.rel: %.c
 	$(CC) $(CFLAGS) $(INCLUDE) -D$(DEVICE) -c $? -o $@
 
 $(TARGET): $(PRJ_OBJECTS) $(SPL_OBJECTS) $(EVAL_OBJECTS) $(EVAL_COMM_OBJECTS) $(EVAL_STM8S_128K_OBJECTS)
-	$(AR) -a $(TARGET) $^
+	$(AR) -rc $(TARGET) $^
 
 clean: 
 	rm -fr $(OUTPUT_DIR)

--- a/Project/STM8S_StdPeriph_test/main.c
+++ b/Project/STM8S_StdPeriph_test/main.c
@@ -77,10 +77,10 @@ void main(void)
   CLK_PeripheralClockConfig(CLK_PERIPHERAL_TIMER4, ENABLE);
 
   /* Initialize LED pins in Output Mode */
-  #if (DEVICE==STM8S103)    // 1$ STM8 board, see https://www.cnx-software.com/2015/01/18/one-dollar-development-board/
+  #if defined(STM8S103)    // 1$ STM8 board, see https://www.cnx-software.com/2015/01/18/one-dollar-development-board/
     GPIO_Init(GPIOD, (GPIO_Pin_TypeDef)GPIO_PIN_3, GPIO_MODE_OUT_PP_LOW_FAST);
     GPIO_WriteHigh(GPIOD, (GPIO_Pin_TypeDef)GPIO_PIN_3);
-  #elif (DEVICE==STM8S208)  // muBoard, see https://frosch.piandmore.de//de/pam9/call/public-media/event_media/160611_Vortrag_Interpreter.pdf
+  #elif defined(STM8S208)  // muBoard, see https://frosch.piandmore.de//de/pam9/call/public-media/event_media/160611_Vortrag_Interpreter.pdf
     GPIO_Init(GPIOH, (GPIO_Pin_TypeDef)(GPIO_PIN_2 | GPIO_PIN_3), GPIO_MODE_OUT_PP_LOW_FAST);
     GPIO_WriteHigh(GPIOH, (GPIO_Pin_TypeDef)(GPIO_PIN_2 | GPIO_PIN_3));
   #else
@@ -128,9 +128,9 @@ void main(void)
       if ((g_count1ms % 500) == 0)
       {
         // toogle LED
-        #if (DEVICE==STM8S103)
+        #if defined(STM8S103)
           GPIO_WriteReverse(GPIOD, (GPIO_Pin_TypeDef)GPIO_PIN_3);
-        #elif (DEVICE==STM8S208)  // muBoard, see https://frosch.piandmore.de//de/pam9/call/public-media/event_media/160611_Vortrag_Interpreter.pdf
+        #elif defined(STM8S208)  // muBoard, see https://frosch.piandmore.de//de/pam9/call/public-media/event_media/160611_Vortrag_Interpreter.pdf
           GPIO_WriteReverse(GPIOH, (GPIO_Pin_TypeDef)GPIO_PIN_2);
         #else
           #error STM8 board not supported!

--- a/Project/STM8S_StdPeriph_test/main.c
+++ b/Project/STM8S_StdPeriph_test/main.c
@@ -37,21 +37,21 @@
 /* Private define ------------------------------------------------------------*/
 #ifdef _RAISONANCE_
   #define PUTCHAR_PROTOTYPE int putchar (char c)
-  #define GETCHAR_PROTOTYPE int getUart (void)
+  #define GETCHAR_PROTOTYPE int getchar (void)
 #elif defined (_COSMIC_)
   #define PUTCHAR_PROTOTYPE char putchar (char c)
-  #define GETCHAR_PROTOTYPE char getUart (void)
+  #define GETCHAR_PROTOTYPE char getchar (void)
 #elif defined (_SDCC_)                    /* SDCC patch: same types as stdio.h */
   #if SDCC_VERSION >= 30605               // declaration changed in sdcc 3.6.5 (officially with 3.7.0)
     #define PUTCHAR_PROTOTYPE int putchar (int c)
-    #define GETCHAR_PROTOTYPE char getUart (void)
+    #define GETCHAR_PROTOTYPE char getchar (void)
   #else
     #define PUTCHAR_PROTOTYPE void putchar (char c)
-    #define GETCHAR_PROTOTYPE unsigned char getUart (void)
+    #define GETCHAR_PROTOTYPE unsigned char getchar (void)
   #endif 
 #else /* _IAR_ */
   #define PUTCHAR_PROTOTYPE int putchar (int c)
-  #define GETCHAR_PROTOTYPE int getUart (void)
+  #define GETCHAR_PROTOTYPE int getchar (void)
 #endif /* _RAISONANCE_ */
 /* Private macro -------------------------------------------------------------*/
 
@@ -114,7 +114,7 @@ void main(void)
     // if key pressed, send echo and store to flash
     if (UART1_GetFlagStatus(UART1_FLAG_RXNE))
     {
-      val = getUart();
+      val = getchar();
       printf("read %c%c%c", val,10,13);
       
       //FLASH_ProgramByte(addr, val);

--- a/Project/STM8S_StdPeriph_test/main.c
+++ b/Project/STM8S_StdPeriph_test/main.c
@@ -42,9 +42,9 @@
   #define PUTCHAR_PROTOTYPE char putchar (char c)
   #define GETCHAR_PROTOTYPE char getchar (void)
 #elif defined (_SDCC_)                    /* SDCC patch: same types as stdio.h */
-  #if SDCC_VERSION >= 30605               // declaration changed in sdcc 3.6.5 (officially with 3.7.0)
+  #if SDCC_VERSION >= 30700               // declaration changed in sdcc 3.7.0 (see sdccman.pdf)
     #define PUTCHAR_PROTOTYPE int putchar (int c)
-    #define GETCHAR_PROTOTYPE char getchar (void)
+    #define GETCHAR_PROTOTYPE int getchar (void)
   #else
     #define PUTCHAR_PROTOTYPE void putchar (char c)
     #define GETCHAR_PROTOTYPE unsigned char getchar (void)


### PR DESCRIPTION
I'm proposing a new patch set to fix compatibility with newer SDCC versions and board detection in the test application. These issues were partly addressed in the previous pull request (that was merged on Nov 7). However, I believe the getchar() fix is incorrect. While it does make the test program work, it potentially breaks future use of other C library functions that rely on getchar(). The assumption is that the modified getchar() must be made available to the entire C library, not just the test program. I had these changes sitting in my local repo for a few months, but never thought about creating a pull request :-/

The other fix is related to board detection in the test program and has not been addressed previously. The DEVICE variable from the Makefile is not exposed to the C compiler, only its value is - which then becomes a macro at the C preprocessor level.