### PR TITLE
Minor Change to Avoid Compiler Warnings with SDCC

### DIFF
--- a/Libraries/STM8S_StdPeriph_Driver/inc/stm8s.h
+++ b/Libraries/STM8S_StdPeriph_Driver/inc/stm8s.h
@@ -2791,11 +2791,11 @@ CFG_TypeDef;
  
 /* SDCC patch: declare ISR handlers */
 #ifdef _SDCC_
- #define INTERRUPT_HANDLER(a,b) void a() __interrupt(b)
+ #define INTERRUPT_HANDLER(a,b) void a(void) __interrupt(b)
 
  /* traps require >=v3.4.3 */
  #if SDCC_VERSION >= 30403
-   #define INTERRUPT_HANDLER_TRAP(a) void a() __trap 
+   #define INTERRUPT_HANDLER_TRAP(a) void a(void) __trap 
  #else
    #error traps require SDCC >=3.4.3. Please update!
  #endif 


### PR DESCRIPTION
I use this library with the [stm8s_it.c](https://github.com/bschwand/STM8-SPL-SDCC/blob/master/Project/STM8S_StdPeriph_Template/stm8s_it.c) and [stm8s_it.h](https://github.com/bschwand/STM8-SPL-SDCC/blob/master/Project/STM8S_StdPeriph_Template/stm8s_it.h) files to create ISRs. 

The syntax used in these files to define the interrupts is defined in stm8s.h on lines 2793-2803, as well as 2811. However, because the function declaration in stm8s_it.h includes `void` as an argument to the ISRs, the compiler does not recognize the definitions in stm8s_it.c as valid for the declarations in stm8s_it.h.

I added (void) to the defines in stm8s.h so that the declaration matches the definition. 

Example declaration in stm8s_it.h:

```c
    void EXTI_PORTD_IRQHandler(void) INTERRUPT(6); 
```
Example definition in stm8s_it.c

```c
    INTERRUPT_HANDLER(EXTI_PORTD_IRQHandler, 6){}
```

Pre-processor output  before my changes:

```c
    void EXTI_PORTD_IRQHandler() __interrupt(6){}
```

Pre-processor output after my changes

```c
    void EXTI_PORTD_IRQHandler(void) __interrupt(6){}
```

This correctly matches the declaration, and the compiler error is gone. 



